### PR TITLE
Modify relative webfont paths to be /components, not ../

### DIFF
--- a/_base.typography.scss
+++ b/_base.typography.scss
@@ -8,7 +8,7 @@
 $predix-font-family: "GE Inspira Sans", sans-serif !default;
 
 /// @type String [default] - Webfont path
-$inuit-webfont-path: '../px-typography-design/type' !default;
+$inuit-webfont-path: '/components/px-typography-design/type' !default;
 
 @import "px-defaults-design/_settings.defaults.scss";
 @import "px-colors-design/_settings.colors.scss";


### PR DESCRIPTION
By changing '..' to '/components', apps can store their style modules in any given file structure without needing to be left in root. To Illustrate, '..' forces me to:

```
localhost/
   components/
      myApp/
         index.html
         index_styles.css
         layout_styles.css
      px-typography-design/type/
         --font files--
```

By changing this to /components, styles are not forced to be stored the root of myApp, but any directory inside of myApp without needing to modify your SASS file's font paths.

```
localhost/
   components/
      myApp/
         index.html
         styles/
            index_styles.css
            layout_styles.css
      px-typography-design/type/
         --font files--
```
